### PR TITLE
Handle address provider unsupported currencies when creating a new order 

### DIFF
--- a/lib/straight/address_providers/base.rb
+++ b/lib/straight/address_providers/base.rb
@@ -23,6 +23,12 @@ module Straight
       def takes_fees?
         false
       end
+
+      # Address provider is expected to define SUPPORTED_CURRENCIES as an
+      # Enumerable with valid currency codes. e.g. 'EUR', 'USD'
+      def currency_supported?(currency)
+        SUPPORTED_CURRENCIES.include?(currency)
+      end
     end
   end
 end

--- a/lib/straight/exchange_rate_adapters/fiat_adapters/fixer_adapter.rb
+++ b/lib/straight/exchange_rate_adapters/fiat_adapters/fixer_adapter.rb
@@ -4,8 +4,8 @@ module Straight
       FETCH_URL = "http://api.fixer.io/latest?base=#{CROSS_RATE_CURRENCY}"
 
       def rate_for(currency_code)
-        super
-        rate = get_rate_value_from_hash(@rates, 'rates', currency_code)
+        rate = super
+        rate ||= get_rate_value_from_hash(@rates, 'rates', currency_code)
         rate_to_f(rate)
       end
     end

--- a/spec/lib/exchange_rate_adapters/fiat_adapters/fixer_adapter_spec.rb
+++ b/spec/lib/exchange_rate_adapters/fiat_adapters/fixer_adapter_spec.rb
@@ -19,4 +19,8 @@ RSpec.describe Straight::ExchangeRate::FixerAdapter do
     expect( -> { @exchange_adapter.rate_for('KZT') }).to raise_error(Straight::ExchangeRate::Adapter::CurrencyNotSupported)
   end
 
+  it "returns 1.0 when the currency is the FiatAdapter::CROSS_RATE_CURRENCY" do
+    expect(@exchange_adapter.
+      rate_for(Straight::ExchangeRate::FiatAdapter::CROSS_RATE_CURRENCY)).to eq(1.0)
+  end
 end


### PR DESCRIPTION
When trying to create a `#new_order` for a Gateway with an `AddressProvider`
that doesn't support the given currency we now convert that currency to
one the AddressProvider can handle using the `FixerAdapter` rates that apply.
