### PR TITLE
Fix: Order amount with currency

### DIFF
--- a/lib/straight/gateway.rb
+++ b/lib/straight/gateway.rb
@@ -100,23 +100,30 @@ module Straight
           btc_denomination: args[:btc_denomination]
         )
 
+        order = Kernel.const_get(order_class).new
+
         if address_provider.takes_fees?
           address, amount = address_provider.new_address_and_amount(**args)
+
+          if args[:currency] != "BTC"
+            order.amount_with_currency =
+              format("%.2f %s", args[:amount], args[:currency])
+          end
         else
           address = address_provider.new_address(**args)
+
+          if args[:currency] != "BTC"
+            order.exchange_rate = current_exchange_rate(args[:currency])
+            order.currency = args[:currency]
+          end
         end
 
-        order             = Kernel.const_get(order_class).new
         order.gateway     = self
         order.keychain_id = args[:keychain_id]
         order.address     = address
         order.amount      = amount
         order.block_height_created_at = fetch_latest_block_height rescue nil
 
-        unless args[:currency] == "BTC"
-          order.exchange_rate = current_exchange_rate(args[:currency])
-          order.currency = args[:currency]
-        end
 
         order
       end

--- a/lib/straight/gateway.rb
+++ b/lib/straight/gateway.rb
@@ -94,12 +94,13 @@ module Straight
         order = Kernel.const_get(order_class).new
         order.gateway = self
         order.keychain_id = args[:keychain_id]
-        order.currency = args[:currency] || default_currency
         order.block_height_created_at = fetch_latest_block_height rescue nil
+
+         args[:currency] ||= default_currency
 
         args[:amount_from_exchange_rate] = amount_from_exchange_rate(
           args[:amount],
-          currency: order.currency,
+          currency: args[:currency],
           btc_denomination: args[:btc_denomination] || :satoshi,
         )
 
@@ -112,11 +113,9 @@ module Straight
           order.address = address_provider.new_address(**args)
         end
 
-        if address_provider.takes_fees? && order.currency != "BTC"
+        unless args[:currency] == "BTC"
           order.amount_with_currency =
-            format("%.2f %s", args[:amount], order.currency)
-        elsif order.currency != "BTC"
-          order.exchange_rate = current_exchange_rate(order.currency)
+            format("%.2f %s", args[:amount], args[:currency])
         end
 
         order

--- a/lib/straight/gateway.rb
+++ b/lib/straight/gateway.rb
@@ -96,21 +96,20 @@ module Straight
         order.keychain_id = args[:keychain_id]
         order.block_height_created_at = fetch_latest_block_height rescue nil
 
-         args[:currency] ||= default_currency
+        args[:currency] ||= default_currency
 
-        args[:amount_from_exchange_rate] = amount_from_exchange_rate(
-          args[:amount],
-          currency: args[:currency],
-          btc_denomination: args[:btc_denomination] || :satoshi,
-        )
-
-        order.amount = args[:amount_from_exchange_rate]
-
+        # Generates address and calculates amount in satoshi
         if address_provider.takes_fees?
           order.address, order.amount =
             address_provider.new_address_and_amount(**args)
         else
           order.address = address_provider.new_address(**args)
+          order.amount =
+            amount_from_exchange_rate(
+              args[:amount],
+              currency: args[:currency],
+              btc_denomination: args[:btc_denomination] || :satoshi,
+            )
         end
 
         unless args[:currency] == "BTC"

--- a/lib/straight/order.rb
+++ b/lib/straight/order.rb
@@ -27,6 +27,7 @@ module Straight
           address
           amount
           amount_paid
+          amount_with_currency
           block_height_created_at
           callback_url
           currency

--- a/lib/straight/order.rb
+++ b/lib/straight/order.rb
@@ -30,8 +30,6 @@ module Straight
           amount_with_currency
           block_height_created_at
           callback_url
-          currency
-          exchange_rate
           gateway
           keychain_id
           status

--- a/spec/lib/gateway_spec.rb
+++ b/spec/lib/gateway_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe Straight::Gateway do
     expect(@gateway.new_order(amount: 1, keychain_id: 1).address).to eq(expected_address)
   end
 
+  it "when the currency is not BTC saves the order's amount with currency" do
+    @gateway.pubkey = BTC::Keychain.new(seed: "test").xpub
+    order = @gateway.new_order(amount: 15, keychain_id: 1, currency: "EUR")
+    expect(order.amount_with_currency).to eq("15.00 EUR")
+  end
+
+  it "when the currency is BTC doesn't save the order's amount with currency" do
+    @gateway.pubkey = BTC::Keychain.new(seed: "test").xpub
+    order = @gateway.new_order(amount: 15, keychain_id: 1)
+    expect(order.amount_with_currency).to be_nil
+  end
+
   it "calls all the order callbacks" do
     callback1                = double('callback1')
     callback2                = double('callback1')


### PR DESCRIPTION
Related to https://github.com/MyceliumGear/straight-server/pull/60

Now for Payout providers that take fees to generate an address and use their own exchange rate we save the order `amount_with_currency` as a String and skip saving the `exchange_rate` to avoid differences in the rates.
