### PR TITLE
hotfix InsightAdapter

### DIFF
--- a/lib/straight/blockchain_adapters/insight_adapter.rb
+++ b/lib/straight/blockchain_adapters/insight_adapter.rb
@@ -63,11 +63,12 @@ module Straight
       def straighten_transaction(transaction, address: nil)
         total_amount = 0
         tid = transaction["txid"]
-        transaction["vout"].each do |o|
+        vouts = transaction['vout'].select { |o| o && o['scriptPubKey'] && o['scriptPubKey']['addresses'] }
+        vouts.each do |o|
           total_amount += Satoshi.new(o["value"]) if address.nil? || address == o["scriptPubKey"]["addresses"].first
         end
         confirmations = transaction["confirmations"] 
-        outs = transaction["vout"].map { |o| {amount: Satoshi.new(o["value"]).to_i, receiving_address: o["scriptPubKey"]["addresses"].first} }
+        outs = vouts.map { |o| {amount: Satoshi.new(o["value"]).to_i, receiving_address: o["scriptPubKey"]["addresses"].first} }
         block = api_request("/block/", transaction['blockhash'])
 
         {

--- a/lib/straight/blockchain_adapters_dispatcher.rb
+++ b/lib/straight/blockchain_adapters_dispatcher.rb
@@ -45,6 +45,7 @@ module Straight
           @defer_result.set(result)
         end
         p.rescue do |reason|
+          Straight.logger.debug "Blockchain query failed: #{reason.inspect}"
           attempts_counter.modify { |v| v-1 }
           @defer_result.fail(AdaptersError) if attempts_counter.value.zero? && adapters.empty?
           execute_in_parallel(block, adapters) if attempts_counter.value.zero?


### PR DESCRIPTION
This was raising exception before the fix, because `o['scriptPubKey']['addresses']` can be `nil`.

```
a = Straight::Blockchain::InsightAdapter.new('https://insight.gear.mycelium.com/api')
a.fetch_transaction('69c8275c327a744a53e39880e1b87dfb369bef4db5d0d1014a27636fad864090', address: '1JVHw9iyesn9CSTDgbmKgSyyZoH9CFUFaP')
```
