### PR TITLE
Add testnet blockchain adapters again

### DIFF
--- a/lib/straight/gateway.rb
+++ b/lib/straight/gateway.rb
@@ -78,6 +78,10 @@ module Straight
         @blockchain_adapters
       end
 
+      def test_blockchain_adapters
+        @blockchain_adapters.map{ |el| el.class.testnet_adapter rescue next }.compact
+      end
+
       # Creates a new order for the address derived from the pubkey and the keychain_id argument provided.
       # See explanation of this keychain_id argument is in the description for the AddressProvider::Base#new_address method.
       def new_order(args)

--- a/spec/lib/gateway_spec.rb
+++ b/spec/lib/gateway_spec.rb
@@ -145,6 +145,7 @@ RSpec.describe Straight::Gateway do
     it "is using testnet" do
       @gateway.test_mode = true
       allow(@mock_adapter).to receive(:testnet_adapters).and_return(true)
+      expect(@gateway.blockchain_adapters).to_not be nil
       expect(@gateway.blockchain_adapters).to eq(@gateway.test_blockchain_adapters)
     end
 


### PR DESCRIPTION
It seems that the testnet adapters have been removed some time ago (accidentially?) - so it was not possible for me to get testnet mode running on my server (see commit here: 9466b8ad2da2967ab8f43aa17e04f5fe1797e6b1).