### PR TITLE
Mycelium Adapter: Fix wrong calculation of testnet transaction amounts

### DIFF
--- a/lib/straight/blockchain_adapters/mycelium_adapter.rb
+++ b/lib/straight/blockchain_adapters/mycelium_adapter.rb
@@ -144,7 +144,7 @@ module Straight
 
           transaction.outputs.each do |out|
             amount = out.value
-            receiving_address = out.script.standard_address
+            receiving_address = out.script.standard_address(network: @testnet ? BTC::Network.testnet : BTC::Network.default)
             total_amount += amount if address.nil? || address == receiving_address.to_s
             outs << {amount: amount, receiving_address: receiving_address}
           end


### PR DESCRIPTION
The standard_address call only returns the main net address, if network is not specified. 
This PR fixes it.