### PR TITLE
Fix active record, because AR returns false for method_defined?(field)

### DIFF
--- a/lib/straight/order.rb
+++ b/lib/straight/order.rb
@@ -37,8 +37,8 @@ module Straight
           tid
           title
         }.each do |field|
-          attr_reader field unless base.method_defined?(field)
-          attr_writer field unless base.method_defined?("#{field}=")
+          attr_reader field unless base.method_defined?(field) || (base.respond_to?(:attribute_method?) && base.attribute_method?(field))
+          attr_writer field unless base.method_defined?("#{field}=") ||  (base.respond_to?(:attribute_method?) && base.attribute_method?("#{field}="))
         end
         prepend Prependable
         include Includable


### PR DESCRIPTION
Wanted to include the OrderModule into my AR class, but found out that the fields address, status,... have not been saved after calling the corresponding methods.

After investigation I found out that ActiveRecord returns false for the ```method_defined?(field)``` calls, so I added another call to the corresponding AR method.