### PR TITLE
Update btcruby gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.6)
-    btcruby (1.0.3)
+    btcruby (1.7)
       ffi (~> 1.9, >= 1.9.3)
     builder (3.2.2)
     concurrent-ruby (0.9.1)


### PR DESCRIPTION
Straight doesnt work correctly with the current btcruby version, @oleganza relaesed a new one some minutes ago, so it would be great to merge this PR.

I would also be happy about a reply to my question about the maintainance of straight: https://github.com/MyceliumGear/straight/issues/34